### PR TITLE
optimize stdNormCDF

### DIFF
--- a/black-scholes.js
+++ b/black-scholes.js
@@ -15,45 +15,25 @@
  */
 function stdNormCDF(x)
 {
-  var probability = 0;
   // avoid divergence in the series which happens around +/-8 when summing the
   // first 100 terms
-  if(x >= 8)
-  {
-    probability = 1;
-  }
-  else if(x <= -8)
-  {
-    probability = 0;
-  }
-  else
-  {
-    for(var i = 0; i < 100; i++)
-    {
-      probability += (Math.pow(x, 2*i+1)/_doubleFactorial(2*i+1));
-    }
-    probability *= Math.pow(Math.E, -0.5*Math.pow(x, 2));
-    probability /= Math.sqrt(2*Math.PI);
-    probability += 0.5;
-  }
-  return probability;
-}
-
-/**
- * Double factorial.  See {@link http://en.wikipedia.org/wiki/Double_factorial|Wikipedia page}.
- * @private
- *
- * @param {Number} n The number to calculate the double factorial of
- * @returns {Number} The double factorial of n
- */
-function _doubleFactorial(n)
-{
-  var val = 1;
-  for(var i = n; i > 1; i-=2)
-  {
-    val *= i;
-  }
-  return val;
+	if (x >= 8) return 1;
+	if (x <= -8) return 0;
+	let xx = x * x;
+	let probability = 0;
+	let n = x;
+	let d = 1;
+	for (let i = 3; i <= 199; i += 2) {
+		let prev = probability;
+		probability += n / d;
+		if (prev === probability) break;
+		n *= xx;
+		d *= i;
+	}
+	probability *= Math.pow(Math.E, -0.5*Math.pow(x, 2));
+	probability /= Math.sqrt(2*Math.PI);
+	probability += 0.5;
+	return probability;
 }
 
 /**

--- a/black-scholes.js
+++ b/black-scholes.js
@@ -5,6 +5,8 @@
  * @copyright 2014 Matt Loppatto
  */
 
+const sqrt2PI = Math.sqrt(2 * Math.PI);
+
 /**
  * Standard normal cumulative distribution function.  The probability is estimated
  * by expanding the CDF into a series using the first 100 terms.
@@ -30,8 +32,8 @@ function stdNormCDF(x)
 		n *= xx;
 		d *= i;
 	}
-	probability *= Math.pow(Math.E, -0.5*Math.pow(x, 2));
-	probability /= Math.sqrt(2*Math.PI);
+	probability *= Math.exp(-0.5*xx);
+	probability /= sqrt2PI;
 	probability += 0.5;
 	return probability;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,147 @@
+{
+  "name": "black-scholes",
+  "version": "1.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+      "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+      "dev": true,
+      "requires": {
+        "ms": "0.6.2"
+      }
+    },
+    "diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~2.0.0",
+        "inherits": "2",
+        "minimatch": "~0.2.11"
+      }
+    },
+    "graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+      "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+      "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.0.1.tgz",
+      "integrity": "sha1-Whboi4VtDEFF2MaIjCfr1PqxPpA=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.0.0",
+        "diff": "1.0.8",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.3",
+        "growl": "1.8.1",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.0"
+      }
+    },
+    "ms": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+      "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    }
+  }
+}

--- a/test/black-scholes.js
+++ b/test/black-scholes.js
@@ -7,11 +7,11 @@ describe("Black-Scholes", function()
   {
     it("should return a call price of 0.23834902311961947", function()
     {
-      assert.equal(0.23834902311961947, bs.blackScholes(30, 34, .25, .2, .08, "call"));
+      assert.equal(0.23834902311962125, bs.blackScholes(30, 34, .25, .2, .08, "call"));
     });
     it("should return a put price of 3.5651039155492974", function()
     {
-      assert.equal(3.5651039155492974, bs.blackScholes(30, 34, .25, .2, .08, "put"));
+      assert.equal(3.565103915549301, bs.blackScholes(30, 34, .25, .2, .08, "put"));
     });
   });
   describe("t>0, v=0, out-of-the-money", function()
@@ -108,7 +108,7 @@ describe("Black-Scholes", function()
     });
     it("should return 3 standard deviations", function()
     {
-      assert.equal(bs.stdNormCDF(3) - bs.stdNormCDF(-3), 0.99730020393674);
+      assert.equal(bs.stdNormCDF(3) - bs.stdNormCDF(-3), 0.9973002039367396);
     });
   });
   describe("getW", function()


### PR DESCRIPTION
The stdNormCDF function is less than optimal and causing a significant drag on my trading app that needs to recalculate IV every time an option price changes, and follows as many options as possible.

![image](https://user-images.githubusercontent.com/3069027/58529440-4db57980-81a0-11e9-8df2-5ca1e8afbae8.png)

I can't really memoize at the application level because the time variable is constantly changing.

This version memoizes the numerator and denominator of the Taylor series as it goes through the series, converting costly Math.pow and factorial to fast multiplies, and also exits early if the series converges early (10-11 iterations on average).  Finally, it replaces Math.pow(Math.E, ...) with Math.exp, which is *much* faster, and calculates sqrt(2*PI) and x^2 once instead of each loop iteration, which saves a few milliseconds on my million iteration test bed.

It runs in ~1% of the amount of time that the original version takes, and the results differ by <= 2e-16 (on < 0.2% of executions, exactly the same 99.8% of the time), presumably due to precision loss on repetitive multiplication versus Math.pow().  All tests pass.

UPDATE: Switching from Math.pow(Math.E, ...) to Math.exp(...) introduced 3 failing tests and 330 out of 10,000 mismatches (by 1e-16 - a single bit of precision) with the original function.  Chances are, Math.exp is more accurate than Math.pow(Math.E), so I updated the tests with the new results.

The following gist contains the testbed and results: https://gist.github.com/dpwhittaker/365e90fc5b77c1173cc2b959b6b71dbf